### PR TITLE
consolidate ci tasks into one job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,21 +4,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
       - run: pnpm lint
-  format:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
       - run: pnpm format
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/actions/setup
       - run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  lint/format/test:
+  format-lint-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  ci:
+  lint/format/test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup
-      - run: pnpm lint
       - run: pnpm format
+      - run: pnpm lint
       - run: pnpm test


### PR DESCRIPTION
At this point running each step (checking format, linting, running tests) is much less work than the overhead that is building the project itself.
It doesn't seem like there's a way to parallelize these steps without wasting time by building the same project 3 times, so I've put it all in one step for now which only performs the build once.